### PR TITLE
Add HTTP Capsule support

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -18,9 +18,10 @@ jobs:
       run: |
         curl -sSLf https://www.iana.org/assignments/quic/quic.xml -o quic.xml
         curl -sSLf https://www.iana.org/assignments/http3-parameters/http3-parameters.xml -o h3.xml
+        curl -sSLf https://www.iana.org/assignments/masque/masque.xml -o masque.xml
     - name: "Commit Changes"
       run: |
         if [ -n "$(git status --porcelain)" ]; then
-          git commit -m "Update registry" quic.xml h3.xml
+          git commit -m "Update registry" quic.xml h3.xml masque.xml
           git push
         fi

--- a/index.html
+++ b/index.html
@@ -45,6 +45,9 @@
         "http3-parameters-error-codes": "h3error",
         "http3-parameters-stream-types": "h3stream",
       },
+      "masque.xml": {
+        "http-capsule-types": "capsule"
+      },
     };
     let taken = {};
 
@@ -150,6 +153,10 @@
       return await vi62gmod(r, bytes, 27n, 31n);
     }
 
+    async function vi62g27mod41(r, bytes) {
+      return await vi62gmod(r, bytes, 27n, 31n);
+    }
+
     const rules = {
       version: { r: version, bits: 32 },
       tp: { r: vi62g27mod31 },
@@ -159,6 +166,7 @@
       h3setting: { r: vi62g2mod31 },
       h3error: { r: vi62g2mod31 },
       h3stream: { r: vi62g2mod31 },
+      capsule: { r: vi62g27mod41 },
     };
 
     async function draw(f, bytes, field) {
@@ -225,12 +233,14 @@
 
 <body>
   <h1>Random Codepoint Selector</h1>
-  <p>If you are looking to use a new codepoint for a QUIC protocol, look no further.
+  <p>If you are looking to use a new codepoint for a protocol, look no further.
   <p>This understands the registries from
     <a href="https://datatracker.ietf.org/doc/html/rfc9000#section-22">Section 22</a> of
-    <a href="https://datatracker.ietf.org/doc/html/rfc9000">QUIC</a> and
+    <a href="https://datatracker.ietf.org/doc/html/rfc9000">QUIC</a>,
     <a href="https://datatracker.ietf.org/doc/html/rfc9114#section-11">Section 11</a> of
-    <a href="https://datatracker.ietf.org/doc/html/rfc9114">HTTP/3</a>.
+    <a href="https://datatracker.ietf.org/doc/html/rfc9114">HTTP/3</a>, and 
+    <a href="https://datatracker.ietf.org/doc/html/rfc9297#section-5.4">Section 5.4</a> of
+    <a href="https://datatracker.ietf.org/doc/html/rfc9114">HTTP Datagrams and the Capsule Protocol</a>.
   <p>The tool is deterministic and checks for codepoints
     that are either reserved or already allocated.
   <table>
@@ -254,11 +264,12 @@
             <option value="frame">Frame</option>
             <option value="error">Error Code</option>
           </optgroup>
-          <optgroup label="HTTP/3">
-            <option value="h3frame">Frame</option>
-            <option value="h3setting">Setting</option>
-            <option value="h3error">Error Code</option>
-            <option value="h3stream">Stream</option>
+          <optgroup label="HTTP">
+            <option value="h3frame">HTTP/3 Frame</option>
+            <option value="h3setting">HTTP/3 Setting</option>
+            <option value="h3error">HTTP/3 Error Code</option>
+            <option value="h3stream">HTTP/3 Stream</option>
+            <option value="capsule">HTTP Capsule</option>
           </optgroup>
         </select>
       </td>

--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
         "http3-parameters-stream-types": "h3stream",
       },
       "masque.xml": {
-        "http-capsule-types": "capsule"
+        "http-capsule-types": "capsule",
       },
     };
     let taken = {};
@@ -246,7 +246,7 @@
     <a href="https://datatracker.ietf.org/doc/html/rfc9114#section-11">Section 11</a> of
     <a href="https://datatracker.ietf.org/doc/html/rfc9114">HTTP/3</a>, and 
     <a href="https://datatracker.ietf.org/doc/html/rfc9297#section-5.4">Section 5.4</a> of
-    <a href="https://datatracker.ietf.org/doc/html/rfc9114">HTTP Datagrams and the Capsule Protocol</a>.
+    <a href="https://datatracker.ietf.org/doc/html/rfc9297">HTTP Datagrams and the Capsule Protocol</a>.
   <p>The tool is deterministic and checks for codepoints
     that are either reserved or already allocated.
   <table>
@@ -275,8 +275,8 @@
             <option value="h3setting">HTTP/3 Setting</option>
             <option value="h3error">HTTP/3 Error Code</option>
             <option value="h3stream">HTTP/3 Stream</option>
-            <option value="capsule">HTTP Capsule</option>
           </optgroup>
+          <option value="capsule">HTTP Capsule</option>
         </select>
       </td>
     </tr>

--- a/masque.xml
+++ b/masque.xml
@@ -1,0 +1,104 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-stylesheet type="text/xsl" href="masque.xsl"?>
+<?xml-model href="masque.rng" schematypens="http://relaxng.org/ns/structure/1.0" ?>
+<registry xmlns="http://www.iana.org/assignments" id="masque">
+  <title>Multiplexed Application Substrate over QUIC Encryption (MASQUE)</title>
+  <created>2022-06-23</created>
+  <updated>2023-10-20</updated>
+
+  <registry id="masque-uri-suffixes">
+    <title>MASQUE URI Suffixes</title>
+    <registration_rule>Expert Review</registration_rule>
+    <xref type="rfc" data="rfc9484"/>
+    <expert>Tommy Pauly, Magnus Westerlund</expert>
+    <record date="2023-05-16">
+      <value>udp</value>
+      <description>UDP Proxying</description>
+      <xref type="rfc" data="rfc9298"/>
+    </record>
+    <record date="2023-05-16">
+      <value>ip</value>
+      <description>IP Proxying</description>
+      <xref type="rfc" data="rfc9484"/>
+    </record>      
+  </registry>
+
+<registry id="http-capsule-types">
+    <title>HTTP Capsule Types</title>
+    <xref type="rfc" data="rfc9297"/>
+    <expert>Lucas Pardue, David Schinazi</expert>
+    <range>
+      <value>provisional</value>
+      <registration_rule>Expert Review</registration_rule>
+    </range>
+    <range>
+      <value>Date field update for provisional registrations</value>
+      <registration_rule>First Come First Served</registration_rule>
+    </range>
+    <range>
+      <value>permanent, 0x00-0x3f</value>
+      <registration_rule>Standards Action or IESG Approval</registration_rule>
+    </range>
+    <range>
+      <value>permanent, greater than 0x3f</value>
+      <registration_rule>Specification Required</registration_rule>
+    </range>
+    <range>
+      <value>first unassigned codepoint</value>
+      <registration_rule>Standards Action</registration_rule>
+    </range>
+    <range>
+      <value>values 0x29 * N + 0x17 (for integer values of N)</value>
+      <registration_rule>Reserved</registration_rule>
+    </range>
+    <record date="2022-06-23">
+      <value>0x00</value>
+      <description>DATAGRAM</description>
+      <status>permanent</status>
+      <xref type="rfc" data="rfc9297"/>
+      <date>2022-06-23</date>
+      <controller>IETF</controller>
+      <contact><xref type="person" data="MASQUE_WG"/></contact>
+      <notes/>
+    </record>
+    <record date="2023-03-06" updated="2023-05-16">
+      <value>0x01</value>
+      <description>ADDRESS_ASSIGN</description>
+      <status>permanent</status>
+      <xref type="rfc" data="rfc9484"/>
+      <date>2023-05-16</date>
+      <controller>IETF</controller>
+      <contact><xref type="person" data="MASQUE_WG"/></contact>
+      <notes/>
+    </record>
+    <record date="2023-03-06" updated="2023-05-16">
+      <value>0x02</value>
+      <description>ADDRESS_REQUEST</description>
+      <status>permanent</status>
+      <xref type="rfc" data="rfc9484"/>
+      <date>2023-05-16</date>
+      <controller>IETF</controller>
+      <contact><xref type="person" data="MASQUE_WG"/></contact>
+      <notes/>
+    </record>
+    <record date="2023-03-06" updated="2023-05-16">
+      <value>0x03</value>
+      <description>ROUTE_ADVERTISEMENT</description>
+      <status>permanent</status>
+      <xref type="rfc" data="rfc9484"/>
+      <date>2023-05-16</date>
+      <controller>IETF</controller>
+      <contact><xref type="person" data="MASQUE_WG"/></contact>
+      <notes/>
+    </record>
+  </registry>
+
+  <people>
+    <person id="MASQUE_WG">
+      <name>MASQUE Working Group</name>
+      <uri>mailto:masque&amp;ietf.org</uri>
+      <updated>2023-03-06</updated>
+    </person>
+  </people>
+
+</registry>


### PR DESCRIPTION
Not 100% if this the correct way to add new registries (some readme advice on contributions would be useful). 

Took some liberties to adjust language to accomodate capsules, which aren't anything to do with QUIC apart from the varint and grease range mechanism.

Aside: its a tiny bit annoying that QUIC registries used decimal values for grease, while H3 and capsules used hex, but /shrug 