### PR TITLE
Extract algorithm into quick-pick.js module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,53 @@
 # Pick a QUIC Codepoint
 
 https://martinthomson.github.io/quic-pick/
+
+## Programmatic use
+
+The selection algorithm is available as an ES module (`quic-pick.js`) for
+use in build tooling and scripts, without needing a browser.
+
+### Browser
+
+Serve the files over HTTPS (module imports don't work over `file://`) and
+import in a `<script type="module">`:
+
+```html
+<script type="module">
+  import { pick } from './quic-pick.js';
+  const codepoint = await pick({ seed: 'draft-foo-bar-01', field: 'frame', bytes: 8 });
+</script>
+```
+
+### Node.js
+
+Node 18+ has a global `fetch`, so no extra setup is needed:
+
+```js
+import { pick } from './quic-pick.js';
+const codepoint = await pick({ seed: 'draft-foo-bar-01', field: 'frame', bytes: 8 });
+```
+
+For older Node versions, pass a `fetchFn`:
+
+```js
+import https from 'https';
+
+function fetchFn(url) {
+  return new Promise((resolve, reject) => {
+    https.get(url, res => {
+      let data = '';
+      res.on('data', chunk => data += chunk);
+      res.on('end', () => resolve({ text: async () => data }));
+    }).on('error', reject);
+  });
+}
+
+const codepoint = await pick({ seed: 'draft-foo-bar-01', field: 'frame', bytes: 8, fetchFn });
+```
+
+### Tests
+
+```sh
+node test.mjs
+```

--- a/index.html
+++ b/index.html
@@ -149,163 +149,13 @@
   </table>
   <p>This project is hosted on <a href="https://github.com/martinthomson/quic-pick">GitHub</a>.
 </body>
-<script>
-  const sources = {
-    "quic.xml": {
-      "quic-versions": "version",
-      "quic-transport": "tp",
-      "quic-frame-types": "frame",
-      "quic-transport-error-codes": "error",
-    },
-    "h3.xml": {
-      "http3-parameters-frame-types": "h3frame",
-      "http3-parameters-settings": "h3setting",
-      "http3-parameters-error-codes": "h3error",
-      "http3-parameters-stream-types": "h3stream",
-    },
-    "masque.xml": {
-      "http-capsule-types": "capsule",
-    },
-  };
-  let taken = {};
+<script type="module">
+  import { rules, draw } from './quic-pick.js';
+
   let urlcodepoint = null;
-
-  async function getTaken(n) {
-    const url = Object.keys(sources).find(s => Object.values(sources[s]).indexOf(n) >= 0);
-    if (!url) { throw `Unable to find source for ${n}`; }
-    console.log(`loading database from ${url} (for ${n})...`);
-
-    const text = await (await fetch(url)).text();
-    const xml = (new DOMParser).parseFromString(text, "text/xml");
-    for (reg of xml.documentElement.children) {
-      if (reg.localName !== "registry") { continue; }
-      const id = reg.getAttribute("id");
-      if (!(id in sources[url])) { continue; }
-
-      let values = [];
-      for (rec of reg.children) {
-        if (rec.localName === "record") {
-          for (e of rec.children) {
-            if (e.localName === "value") {
-              let [start, end] = e.textContent.trim().split("-").map(v => BigInt(v));
-              do {
-                values.push(start++);
-              } while (start < end ?? start);
-            }
-          }
-        }
-      }
-      const field = sources[url][id];
-      taken[field] = values;
-      console.log(`...loaded ${values.length} values for ${field}`);
-    }
-  }
-
-  async function isTaken(v, field) {
-    if (!(field in taken)) {
-      await getTaken(field);
-    }
-    return taken[field].indexOf(v) >= 0;
-  }
 
   function el(i) {
     return document.getElementById(i);
-  }
-
-  async function hash(v) {
-    return await crypto.subtle.digest({ name: "SHA-256" }, v);
-  }
-
-  function rng() {
-    const s = "quic-pick-" + el("seed").value;
-    const base = (new TextEncoder()).encode(s);
-    const offset = base.length;
-    let counter = 0;
-    let seed = new Uint8Array(offset + 2);
-    seed.set(base, 0);
-    return async function (bits) {
-      seed.set([(counter >> 8) & 0xff, counter & 0xff], offset);
-      const r = new Uint8Array(await hash(seed));
-      const shift = 8 - (bits % 8);
-      let v = BigInt((shift === 8) ? r[0] : r[0] >> shift);
-      let i = 1;
-      for (let bytes = (bits - 1) >> 3; bytes > 0; --bytes) {
-        v = (v << 8n) | BigInt(r[i++]);
-      }
-      counter++;
-      return v;
-    };
-  }
-
-  async function version(r, _bytes) {
-    // A QUIC version number.
-    r ??= rng();
-    let v;
-    do {
-      v = await r(32);
-    } while ((v & 0x0f0f0f0fn) === 0x0a0a0a0an);
-    return v;
-  }
-
-  async function vi62(r, bytes) {
-    // An unfiltered QUIC varint.
-    r ??= rng();
-    const shift = BigInt((bytes >> 1) * 8 - 2);
-    let v;
-    do {
-      v = await r(bytes * 8 - 2);
-    } while (v < (1n << shift));
-    return v;
-  }
-
-  async function vi62gmod(r, bytes, rem, div) {
-    // A 62-bit QUIC varint, except those equal to $rem mod $div,
-    // except for any value that is less than $rem (so 2 is ok for 33 mod 31).
-    let v;
-    do {
-      v = await vi62(r, bytes);
-    } while (v % div === rem % div && v >= rem);
-    return v;
-  }
-
-  async function vi62g2mod31(r, bytes) {
-    return await vi62gmod(r, bytes, 33n, 31n);
-  }
-
-  async function vi62g27mod31(r, bytes) {
-    return await vi62gmod(r, bytes, 27n, 31n);
-  }
-
-  async function vi62g23mod41(r, bytes) {
-    return await vi62gmod(r, bytes, 23n, 41n);
-  }
-
-  const rules = {
-    version: { r: version, bits: 32 },
-    tp: { r: vi62g27mod31 },
-    frame: { r: vi62 },
-    error: { r: vi62 },
-    h3frame: { r: vi62g2mod31 },
-    h3setting: { r: vi62g2mod31 },
-    h3error: { r: vi62g2mod31 },
-    h3stream: { r: vi62g2mod31 },
-    capsule: { r: vi62g23mod41 },
-  };
-
-  async function draw(n, f, bytes, field) {
-    const tries = 32;
-    let r = rng();
-    outer: for (let i = 0; i < tries; ++i) {
-      const v = await f(r, bytes);
-      for (let j = 0n; j < n; ++j) {
-        if (await isTaken(v + j, field)) {
-          console.log(`draw ${i + 1} for ${field}: ${v.toString(16)} taken@${(v + j).toString(16)} (offset ${j})`);
-          continue outer;
-        }
-      }
-      return v;
-    }
-    throw `failed to generate a value for ${field} after ${tries} draws`;
   }
 
   function resetDecoration(cp) {
@@ -355,7 +205,7 @@
       const count = BigInt(parseInt(el("count").value, 10));
 
       try {
-        const v = await draw(count, rule.r, bytes, field);
+        const v = await draw(count, el("seed").value, rule.r, bytes, field);
         const padlen = (bits === 62) ? (bytes * 2) : Math.ceil(bits / 4);
         const pad = v => v.toString(16).padStart(padlen, "0");
         const vstr = v.toString(16).padStart(padlen, "0");
@@ -386,7 +236,8 @@
       sel.textContent = s;
 
       function cleanupLabels() {
-        for (opt of f.options) {
+        // const required: module scope is strict, undeclared vars throw
+        for (const opt of f.options) {
           opt.textContent = cutLast(opt);
         }
         f.removeEventListener("click", cleanupLabels);

--- a/index.html
+++ b/index.html
@@ -236,7 +236,6 @@
       sel.textContent = s;
 
       function cleanupLabels() {
-        // const required: module scope is strict, undeclared vars throw
         for (const opt of f.options) {
           opt.textContent = cutLast(opt);
         }

--- a/quic-pick.js
+++ b/quic-pick.js
@@ -211,18 +211,6 @@ export async function draw(n, seed, f, bytes, field, fetchFn) {
 }
 
 /**
- * Select a codepoint deterministically for a given seed and field type.
- *
- * @param {object} options
- * @param {string} options.seed - Seed string (e.g. 'draft-foo-bar-01_frame').
- * @param {string} options.field - Registry field name (e.g. 'frame', 'tp', 'version').
- * @param {number} [options.bytes=8] - Encoded size in bytes (1, 2, 4, or 8).
- * @param {number|bigint} [options.count=1] - Number of consecutive values needed.
- * @param {Function} [options.fetchFn] - fetch override; required in Node.js environments
- *   that don't have a global fetch (Node < 18).
- * @returns {Promise<bigint>} The selected codepoint (start of range if count > 1).
- */
-/**
  * Generate a permalink URL for a given codepoint selection.
  * The URL can be used to verify the selection on the quic-pick website.
  *
@@ -243,6 +231,18 @@ export function permalink({ seed, field, codepoint, bytes = 8, count = 1n, baseU
   return url;
 }
 
+/**
+ * Select a codepoint deterministically for a given seed and field type.
+ *
+ * @param {object} options
+ * @param {string} options.seed - Seed string (e.g. 'draft-foo-bar-01_frame').
+ * @param {string} options.field - Registry field name (e.g. 'frame', 'tp', 'version').
+ * @param {number} [options.bytes=8] - Encoded size in bytes (1, 2, 4, or 8).
+ * @param {number|bigint} [options.count=1] - Number of consecutive values needed.
+ * @param {Function} [options.fetchFn] - fetch override; required in Node.js environments
+ *   that don't have a global fetch (Node < 18).
+ * @returns {Promise<bigint>} The selected codepoint (start of range if count > 1).
+ */
 export async function pick({ seed, field, bytes = 8, count = 1n, fetchFn } = {}) {
   if (!seed) { throw new Error('seed is required'); }
   if (!field) { throw new Error('field is required'); }

--- a/quic-pick.js
+++ b/quic-pick.js
@@ -1,0 +1,246 @@
+/**
+ * quic-pick.js - deterministic QUIC codepoint selection algorithm
+ *
+ * Works in both browsers and Node.js (v18+).
+ * See README.md for usage and examples.
+ */
+
+const BASE_URL = 'https://martinthomson.github.io/quic-pick/';
+
+/**
+ * Maps registry XML filenames to their IANA registry ID -> field name.
+ * @type {Object.<string, Object.<string, string>>}
+ */
+export const sources = {
+  "quic.xml": {
+    "quic-versions": "version",
+    "quic-transport": "tp",
+    "quic-frame-types": "frame",
+    "quic-transport-error-codes": "error",
+  },
+  "h3.xml": {
+    "http3-parameters-frame-types": "h3frame",
+    "http3-parameters-settings": "h3setting",
+    "http3-parameters-error-codes": "h3error",
+    "http3-parameters-stream-types": "h3stream",
+  },
+  "masque.xml": {
+    "http-capsule-types": "capsule",
+  },
+};
+
+// Already-assigned codepoints, keyed by field name. Populated lazily.
+let taken = {};
+
+async function getTaken(n, fetchFn) {
+  fetchFn ??= fetch;
+  const file = Object.keys(sources).find(s => Object.values(sources[s]).indexOf(n) >= 0);
+  if (!file) { throw new Error(`Unable to find source for ${n}`); }
+  console.log(`loading database from ${file} (for ${n})...`);
+
+  const url = new URL(file, BASE_URL).href;
+  const text = await (await fetchFn(url)).text();
+
+  // Use DOMParser in browsers; fall back to regex in Node.js.
+  let registries;
+  if (typeof DOMParser !== 'undefined') {
+    const xml = (new DOMParser).parseFromString(text, "text/xml");
+    registries = [...xml.documentElement.children]
+      .filter(r => r.localName === "registry")
+      .map(r => ({
+        id: r.getAttribute("id"),
+        values: [...r.children]
+          .filter(rec => rec.localName === "record")
+          .flatMap(rec => [...rec.children]
+            .filter(e => e.localName === "value")
+            .map(e => e.textContent.trim())),
+      }));
+  } else {
+    registries = [];
+    const regPattern = /<registry[^>]*id="([^"]+)"[^>]*>([\s\S]*?)<\/registry>/g;
+    let rm;
+    while ((rm = regPattern.exec(text)) !== null) {
+      const id = rm[1];
+      const body = rm[2];
+      const values = [];
+      const valPattern = /<value>([^<]+)<\/value>/g;
+      let vm;
+      while ((vm = valPattern.exec(body)) !== null) {
+        values.push(vm[1].trim());
+      }
+      registries.push({ id, values });
+    }
+  }
+
+  for (const { id, values } of registries) {
+    if (!(id in sources[file])) { continue; }
+    const field = sources[file][id];
+    const parsed = [];
+    for (const raw of values) {
+      try {
+        let [start, end] = raw.split("-").map(v => BigInt(v));
+        do {
+          parsed.push(start++);
+        } while (start < (end ?? start));
+      } catch {
+        // skip non-numeric values (e.g. "provisional", "permanent, 0x00-0x3f")
+      }
+    }
+    taken[field] = parsed;
+    console.log(`...loaded ${parsed.length} values for ${field}`);
+  }
+}
+
+async function isTaken(v, field, fetchFn) {
+  if (!(field in taken)) {
+    await getTaken(field, fetchFn);
+  }
+  return taken[field].indexOf(v) >= 0;
+}
+
+async function hash(v) {
+  return await globalThis.crypto.subtle.digest({ name: "SHA-256" }, v);
+}
+
+function rng(seed) {
+  const s = "quic-pick-" + seed;
+  const base = (new TextEncoder()).encode(s);
+  const offset = base.length;
+  let counter = 0;
+  let seedBuf = new Uint8Array(offset + 2);
+  seedBuf.set(base, 0);
+  return async function (bits) {
+    seedBuf.set([(counter >> 8) & 0xff, counter & 0xff], offset);
+    const r = new Uint8Array(await hash(seedBuf));
+    const shift = 8 - (bits % 8);
+    let v = BigInt((shift === 8) ? r[0] : r[0] >> shift);
+    let i = 1;
+    for (let bytes = (bits - 1) >> 3; bytes > 0; --bytes) {
+      v = (v << 8n) | BigInt(r[i++]);
+    }
+    counter++;
+    return v;
+  };
+}
+
+async function version(r, _bytes) {
+  // A QUIC version number.
+  r ??= rng();
+  let v;
+  do {
+    v = await r(32);
+  } while ((v & 0x0f0f0f0fn) === 0x0a0a0a0an);
+  return v;
+}
+
+async function vi62(r, bytes) {
+  // An unfiltered QUIC varint.
+  r ??= rng();
+  const shift = BigInt((bytes >> 1) * 8 - 2);
+  let v;
+  do {
+    v = await r(bytes * 8 - 2);
+  } while (v < (1n << shift));
+  return v;
+}
+
+async function vi62gmod(r, bytes, rem, div) {
+  // A 62-bit QUIC varint, except those equal to $rem mod $div,
+  // except for any value that is less than $rem (so 2 is ok for 33 mod 31).
+  let v;
+  do {
+    v = await vi62(r, bytes);
+  } while (v % div === rem % div && v >= rem);
+  return v;
+}
+
+async function vi62g2mod31(r, bytes) {
+  return await vi62gmod(r, bytes, 33n, 31n);
+}
+
+async function vi62g27mod31(r, bytes) {
+  return await vi62gmod(r, bytes, 27n, 31n);
+}
+
+async function vi62g23mod41(r, bytes) {
+  return await vi62gmod(r, bytes, 23n, 41n);
+}
+
+/**
+ * Maps field names to their generator function and optional fixed bit width.
+ * @type {Object.<string, {r: Function, bits?: number}>}
+ */
+export const rules = {
+  version:   { r: version,      bits: 32 },
+  tp:        { r: vi62g27mod31 },
+  frame:     { r: vi62 },
+  error:     { r: vi62 },
+  h3frame:   { r: vi62g2mod31 },
+  h3setting: { r: vi62g2mod31 },
+  h3error:   { r: vi62g2mod31 },
+  h3stream:  { r: vi62g2mod31 },
+  capsule:   { r: vi62g23mod41 },
+};
+
+/**
+ * Pick a starting codepoint for n consecutive values, using a given generator.
+ * Retries up to 32 times if any value in the range is already taken.
+ *
+ * @param {bigint} n - Number of consecutive values required.
+ * @param {string} seed - Seed string for the RNG.
+ * @param {Function} f - Generator function (e.g. vi62, vi62g27mod31).
+ * @param {number} bytes - Encoded size in bytes (1, 2, 4, or 8).
+ * @param {string} field - Registry field name (e.g. 'frame', 'tp').
+ * @param {Function} [fetchFn] - Optional fetch override for loading registries.
+ * @returns {Promise<bigint>} The selected codepoint.
+ */
+export async function draw(n, seed, f, bytes, field, fetchFn) {
+  const tries = 32;
+  let r = rng(seed);
+  outer: for (let i = 0; i < tries; ++i) {
+    const v = await f(r, bytes);
+    for (let j = 0n; j < n; ++j) {
+      if (await isTaken(v + j, field, fetchFn)) {
+        console.log(`draw ${i + 1} for ${field}: ${v.toString(16)} taken@${(v + j).toString(16)} (offset ${j})`);
+        continue outer;
+      }
+    }
+    return v;
+  }
+  throw new Error(`failed to generate a value for ${field} after ${tries} draws`);
+}
+
+/**
+ * Select a codepoint deterministically for a given seed and field type.
+ *
+ * @param {object} options
+ * @param {string} options.seed - Seed string (e.g. 'draft-foo-bar-01_frame').
+ * @param {string} options.field - Registry field name (e.g. 'frame', 'tp', 'version').
+ * @param {number} [options.bytes=8] - Encoded size in bytes (1, 2, 4, or 8).
+ * @param {number|bigint} [options.count=1] - Number of consecutive values needed.
+ * @param {Function} [options.fetchFn] - fetch override; required in Node.js environments
+ *   that don't have a global fetch (Node < 18).
+ * @returns {Promise<bigint>} The selected codepoint (start of range if count > 1).
+ */
+export async function pick({ seed, field, bytes = 8, count = 1n, fetchFn } = {}) {
+  if (!seed) { throw new Error('seed is required'); }
+  if (!field) { throw new Error('field is required'); }
+  const rule = rules[field];
+  if (!rule) { throw new Error(`Unknown field: ${field}`); }
+
+  const r = rng(seed);
+  const n = BigInt(count);
+  const tries = 32;
+
+  outer: for (let i = 0; i < tries; ++i) {
+    const v = await rule.r(r, bytes);
+    for (let j = 0n; j < n; ++j) {
+      if (await isTaken(v + j, field, fetchFn)) {
+        console.log(`draw ${i + 1} for ${field}: ${v.toString(16)} taken@${(v + j).toString(16)} (offset ${j})`);
+        continue outer;
+      }
+    }
+    return v;
+  }
+  throw new Error(`failed to generate a value for ${field} after ${tries} draws`);
+}

--- a/quic-pick.js
+++ b/quic-pick.js
@@ -222,6 +222,27 @@ export async function draw(n, seed, f, bytes, field, fetchFn) {
  *   that don't have a global fetch (Node < 18).
  * @returns {Promise<bigint>} The selected codepoint (start of range if count > 1).
  */
+/**
+ * Generate a permalink URL for a given codepoint selection.
+ * The URL can be used to verify the selection on the quic-pick website.
+ *
+ * @param {object} options
+ * @param {string} options.seed - Seed string used for selection.
+ * @param {string} options.field - Registry field name (e.g. 'frame', 'tp').
+ * @param {bigint} options.codepoint - The selected codepoint value.
+ * @param {number} [options.bytes=8] - Encoded size in bytes (1, 2, 4, or 8).
+ * @param {bigint} [options.count=1n] - Number of consecutive values.
+ * @param {string} [options.baseUrl] - Base URL of the quic-pick tool.
+ * @returns {string} A permalink URL.
+ */
+export function permalink({ seed, field, codepoint, bytes = 8, count = 1n, baseUrl = BASE_URL } = {}) {
+  const cpStr = `0x${codepoint.toString(16).padStart(bytes * 2, '0')}`;
+  let url = `${baseUrl}#seed=${encodeURIComponent(seed)};field=${field};codepoint=${encodeURIComponent(cpStr)}`;
+  if (count > 1n) url += `;count=${count}`;
+  url += `;size=${bytes}`;
+  return url;
+}
+
 export async function pick({ seed, field, bytes = 8, count = 1n, fetchFn } = {}) {
   if (!seed) { throw new Error('seed is required'); }
   if (!field) { throw new Error('field is required'); }

--- a/test.mjs
+++ b/test.mjs
@@ -1,62 +1,55 @@
 // Basic test for quic-pick.js module
 // Usage: node test.mjs
 
-import https from 'https';
+import { readFile } from 'fs/promises';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
 import { pick } from './quic-pick.js';
 
-function fetchShim(url) {
-  return new Promise((resolve, reject) => {
-    https.get(url, res => {
-      if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
-        return resolve(fetchShim(res.headers.location));
-      }
-      let data = '';
-      res.on('data', chunk => data += chunk);
-      res.on('end', () => resolve({ text: async () => data }));
-    }).on('error', reject);
-  });
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function loadLocalFile(url) {
+  const filename = new URL(url).pathname.split('/').pop();
+  const filepath = join(__dirname, filename);
+  return readFile(filepath, 'utf-8').then(data => ({ text: async () => data }));
 }
 
 let passed = 0;
 let failed = 0;
 
-function check(label, actual, expected) {
-  if (actual === expected) {
-    console.log(`  PASS  ${label}: 0x${actual.toString(16)}`);
+function check(label, a, b, shouldEqual) {
+  const ok = shouldEqual ? a === b : a !== b;
+  if (ok) {
+    console.log(`  PASS  ${label}`);
     passed++;
   } else {
-    console.error(`  FAIL  ${label}: got 0x${actual.toString(16)}, expected 0x${expected.toString(16)}`);
+    console.error(`  FAIL  ${label}: 0x${a.toString(16)} ${shouldEqual ? '!==' : '==='} 0x${b.toString(16)}`);
     failed++;
   }
 }
+const assertEq = (label, a, b) => check(label, a, b, true);
+const assertNotEq = (label, a, b) => check(label, a, b, false);
 
 console.log('Testing quic-pick.js module...\n');
 
-// Expected values produced by the updated index.html inline script
-// (verified against the live website at martinthomson.github.io/quic-pick)
-const cases = [
-  { seed: 'draft-ietf-quic-qmux-01_frame', field: 'frame', bytes: 8, count: 1n },
-  { seed: 'draft-ietf-quic-qmux-01_tp',    field: 'tp',    bytes: 8, count: 1n },
-];
-
-// First, compute expected values from the website by running with count=1
-// then check consistency (run twice, should be identical)
-for (const c of cases) {
-  const v1 = await pick({ ...c, fetchFn: fetchShim });
-  const v2 = await pick({ ...c, fetchFn: fetchShim });
-  check(`deterministic: ${c.seed} / ${c.field}`, v1, v2);
+// Check determinism: same inputs should produce identical outputs
+for (const field of ['frame', 'tp']) {
+  const opts = { seed: 'test-draft-example-00', field, bytes: 8, fetchFn: loadLocalFile };
+  const v1 = await pick(opts);
+  const v2 = await pick(opts);
+  assertEq(`deterministic (${field})`, v1, v2);
 }
 
-// Check that frame and tp don't collide
-const frame = await pick({ seed: 'draft-ietf-quic-qmux-01_frame', field: 'frame', bytes: 8, fetchFn: fetchShim });
-const tp    = await pick({ seed: 'draft-ietf-quic-qmux-01_tp',    field: 'tp',    bytes: 8, fetchFn: fetchShim });
-if (frame !== tp) {
-  console.log(`  PASS  no cross-registry collision: frame=0x${frame.toString(16)} tp=0x${tp.toString(16)}`);
-  passed++;
-} else {
-  console.error(`  FAIL  frame and tp have same value: 0x${frame.toString(16)}`);
-  failed++;
-}
+// Check that different seeds produce different values
+const opts = { bytes: 8, fetchFn: loadLocalFile };
+const frame_a = await pick({ seed: 'test-draft-example-00', field: 'frame', ...opts });
+const frame_b = await pick({ seed: 'test-draft-example-01', field: 'frame', ...opts });
+const tp_a    = await pick({ seed: 'test-draft-example-00', field: 'tp',    ...opts });
+const tp_b    = await pick({ seed: 'test-draft-example-01', field: 'tp',    ...opts });
+
+assertNotEq('different seeds, same field (frame)', frame_a, frame_b);
+assertNotEq('different seeds, same field (tp)', tp_a, tp_b);
+assertNotEq('different fields, different seeds', frame_a, tp_b);
 
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);

--- a/test.mjs
+++ b/test.mjs
@@ -1,0 +1,62 @@
+// Basic test for quic-pick.js module
+// Usage: node test.mjs
+
+import https from 'https';
+import { pick } from './quic-pick.js';
+
+function fetchShim(url) {
+  return new Promise((resolve, reject) => {
+    https.get(url, res => {
+      if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+        return resolve(fetchShim(res.headers.location));
+      }
+      let data = '';
+      res.on('data', chunk => data += chunk);
+      res.on('end', () => resolve({ text: async () => data }));
+    }).on('error', reject);
+  });
+}
+
+let passed = 0;
+let failed = 0;
+
+function check(label, actual, expected) {
+  if (actual === expected) {
+    console.log(`  PASS  ${label}: 0x${actual.toString(16)}`);
+    passed++;
+  } else {
+    console.error(`  FAIL  ${label}: got 0x${actual.toString(16)}, expected 0x${expected.toString(16)}`);
+    failed++;
+  }
+}
+
+console.log('Testing quic-pick.js module...\n');
+
+// Expected values produced by the updated index.html inline script
+// (verified against the live website at martinthomson.github.io/quic-pick)
+const cases = [
+  { seed: 'draft-ietf-quic-qmux-01_frame', field: 'frame', bytes: 8, count: 1n },
+  { seed: 'draft-ietf-quic-qmux-01_tp',    field: 'tp',    bytes: 8, count: 1n },
+];
+
+// First, compute expected values from the website by running with count=1
+// then check consistency (run twice, should be identical)
+for (const c of cases) {
+  const v1 = await pick({ ...c, fetchFn: fetchShim });
+  const v2 = await pick({ ...c, fetchFn: fetchShim });
+  check(`deterministic: ${c.seed} / ${c.field}`, v1, v2);
+}
+
+// Check that frame and tp don't collide
+const frame = await pick({ seed: 'draft-ietf-quic-qmux-01_frame', field: 'frame', bytes: 8, fetchFn: fetchShim });
+const tp    = await pick({ seed: 'draft-ietf-quic-qmux-01_tp',    field: 'tp',    bytes: 8, fetchFn: fetchShim });
+if (frame !== tp) {
+  console.log(`  PASS  no cross-registry collision: frame=0x${frame.toString(16)} tp=0x${tp.toString(16)}`);
+  passed++;
+} else {
+  console.error(`  FAIL  frame and tp have same value: 0x${frame.toString(16)}`);
+  failed++;
+}
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
Extract algorithm into quic-pick.js module
    
Move the codepoint selection algorithm out of the inline script in
index.html and into a separate ES module, quic-pick.js. This allows the
algorithm to be imported and used programmatically from Node.js or other browser contexts without scraping the page.
    
The module exports pick() and draw() as the primary API, along with
rules and sources for callers that need lower-level access. Public
functions are documented with JSDoc. Registry loading falls back to a
regex-based XML parser when DOMParser is unavailable (Node.js).
    
index.html is updated to import from the module. Also fixes an
undeclared loop variable (opt) that throws in strict module scope.
    
Adds test.mjs to verify the module produces deterministic results
in Node.js. README.md updated with programmatic usage and test instructions.